### PR TITLE
ETS-65 Handle stale element reference exception

### DIFF
--- a/src/EtsyStats/Program.cs
+++ b/src/EtsyStats/Program.cs
@@ -7,6 +7,7 @@ using EtsyStats.Models.Options;
 using EtsyStats.Services;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
+using OpenQA.Selenium;
 
 namespace EtsyStats;
 
@@ -123,20 +124,23 @@ Console.WriteLine("You should not see this");
                         await Log.Debug("See logs/logs.txt.");
                     }
 
-                    await Log.Error(e.GetBaseException().ToString());
+                    await Log.Error("Invalid Operation Exception\r\n" + e.GetBaseException());
+                }
+                catch (StaleElementReferenceException e)
+                {
+                    await ProgramHelper.OriginalOut.WriteLineAsync("\nThere was an error trying to load listing(s). Please try again.\n\n");
+                    await Log.Error("Stale Element Reference Exception\r\n" + e.GetBaseException());
                 }
                 catch (Exception e)
                 {
                     await ProgramHelper.OriginalOut.WriteLineAsync("\nSomething went wrong. Unexpected error has occured :(\n\n");
-                    await Log.Debug("See logs/logs.txt.");
-                    await Log.Error(e.GetBaseException().ToString());
+                    await Log.Error("Unexpected Exception\r\n" + e.GetBaseException());
                 }
             } while (!exit);
         }
         catch (Exception e)
         {
             await ProgramHelper.OriginalOut.WriteLineAsync("\nSomething went wrong. Unexpected error has occured :(\n\n");
-            await Log.Debug("See logs/logs.txt.");
             await Log.Error(e.GetBaseException().ToString());
         }
 

--- a/src/EtsyStats/Services/EtsyParser.cs
+++ b/src/EtsyStats/Services/EtsyParser.cs
@@ -98,14 +98,17 @@ public class EtsyParser
     private async Task<List<ListingStats>> GetListingsFromPage(SlDriver chromeDriver, WebScrapingService webScrapingService, DateRange dateRange)
     {
         // TODO use API to get listings?
-        var listingLinksElements = chromeDriver.FindElements(By.XPath(ListingsPageXPaths.ListingLink));
-        var listingsIds = listingLinksElements.Select(e => EtsyUrl.GetListingIdFromLink(e.GetAttribute(Href))).ToList();
-
+        var listingsIds = webScrapingService.HandleStaleElements(() =>
+        {
+            var listingLinksElements = chromeDriver.FindElements(By.XPath(ListingsPageXPaths.ListingLink));
+            return listingLinksElements.Select(e => EtsyUrl.GetListingIdFromLink(e.GetAttribute(Href))).ToList();
+        });
+        
         List<ListingStats> listings = new();
         for (var i = 0; i < listingsIds.Count; i++)
         {
             var id = listingsIds[i];
-            await ProgramHelper.OriginalOut.WriteLineAsync($"\nProcessing listing {i + 1} out of  {listingLinksElements.Count}...\n");
+            await ProgramHelper.OriginalOut.WriteLineAsync($"\nProcessing listing {i + 1} out of  {listingsIds.Count}...\n");
 
             var listing = new ListingStats
             {


### PR DESCRIPTION
## Description
StaleElementReferenceException was occurring on trying to access href attribute on listings page.

## What was done
* Wait for elements to be displayed and enabled 
* Wait till StaleElementReferenceException is not longer there when getting href attribute from listings
* Handle StaleElementReferenceException  from Main 